### PR TITLE
Remove money validation

### DIFF
--- a/src/Model/Request/CheckoutSessionConfirmRequestModel.php
+++ b/src/Model/Request/CheckoutSessionConfirmRequestModel.php
@@ -59,7 +59,6 @@ class CheckoutSessionConfirmRequestModel extends AbstractRequestModel
     {
         return [
             'sessionUuid' => 'string',
-            'amount' => Amount::class,
             'duration' => 'integer',
             'company' => DebtorCompany::class,
             'deliveryAddress' => '?' . Address::class,


### PR DESCRIPTION
I am not sure why Confirm payment is failing because of this change 🤔 
My suggestion is to remove the validation from here so that the plugins send the request to us, would be easier to debug if merchants complain to us.
It would remove the need to maintain the validation in the SDK.