### PR TITLE
lock phpunit-version to 11.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=7.0",
+    "phpunit/phpunit": "^9.0 || ^11.0",
     "phpstan/phpstan": "*",
     "rector/rector": "^0.16.0",
     "symplify/easy-coding-standard": "^11.3",


### PR DESCRIPTION
makes sure to not use PHP Attributes for data-provider, which are not available in php 7.4